### PR TITLE
Support chef client 12

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -81,7 +81,7 @@ class Chef
   end
 
   # provider
-  class Provider::Zap < Provider
+  class Provider::Zap < Provider::LWRPBase
     def load_current_resource
       @name  = @new_resource.name
       @klass = [@new_resource.klass].flatten


### PR DESCRIPTION
https://www.chef.io/blog/2014/12/09/release-chef-client-12-0-1/
http://docs.chef.io/upgrade_client_notes.html

> Starting with chef-client 12, the Recipe DSL is removed from the Chef::Provider base class
