### PR TITLE
Add support for the opscode firewall cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ zap Cookbook CHANGELOG
 ======================
 This file is used to list changes made in each version of the zap cookbook.
 
+v0.8.3
+------
+### Improvement
+- Added recipe [zap::firewall] for support for the firewall cookbook (main caller)
+- Added recipe [zap::firewall_iptables] adds iptables support to zap firewall recipe
+- Added recipe [zap::firewall_firewalld] adds firewalld support to zap firewall recipe
+
 v0.8.2
 ------
 ### Improvement

--- a/README.md
+++ b/README.md
@@ -174,6 +174,21 @@ zap_apt_repos '/etc/apt/sources.list.d' do
 end
 ```
 
+zap_firewall
+---------
+
+Delete all firewall rules that were not defined in Chef using the firewall cookbook.
+
+## Actions
+
+- **:remove**
+
+## Example
+
+```ruby
+zap_firewall "cleaning up firewall"
+```
+
 zap
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Thanks
 Users and groups support was provided by Sander Botman <sbotman@schubergphilis.com>.
 Yum_repository support was provided by Sander van Harmelen <svanharmelen@schubergphilis.com>
 Apt_repository support was provided by Helgi Þormar Þorbjörnsson <helgi@php.net>
+firewall support was provided by Ronald Doorn <rdoorn@schubergphilis.com>.
 
 Resource/Provider
 =================

--- a/libraries/firewall.rb
+++ b/libraries/firewall.rb
@@ -41,7 +41,7 @@ class Chef
       case platform
       when "ubuntu", "debian"
         Chef::Log.warn "Zap does not yet support Ufw"
-      when "redhat", "centos"
+      when "redhat", "centos", "amazon", "scientific"
         if version[0].to_i >= 7
           @provider = Provider::ZapFirewallFirewalld
         else

--- a/libraries/firewall.rb
+++ b/libraries/firewall.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+#
+# Cookbook Name:: zap
+# HWRP:: firewall
+#
+# Author:: Ronald Doorn <rdoorn@schubergphilis.com>
+#
+# Copyright:: 2015, Ronald Doorn.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'etc'
+require 'chef/platform'
+require_relative 'default.rb'
+
+# zap_firewall
+class Chef
+  # resource
+  class Resource::ZapFirewall < Resource::Zap
+    def initialize(name, run_context = nil)
+      super
+	
+      # Set the resource name and provider and default action
+      @action = :remove
+      @resource_name = :zap_firewall
+      @klass = Chef::Resource::FirewallRule rescue nil
+      Chef::Log.warn "You are trying to zap a firewall rule, but the firewall LWRPs are not loaded! Did you forgot to depend on the firewall cookbook somewhere?" if @klass.nil?
+
+      platform, version = Chef::Platform.find_platform_and_version(run_context.node)
+      case platform
+      when "ubuntu", "debian"
+        Chef::Log.warn "Zap does not yet support Ufw"
+      when "redhat", "centos"
+        if version[0].to_i >= 7
+          @provider = Provider::ZapFirewallFirewalld
+        else
+          @provider = Provider::ZapFirewallIptables
+        end
+      end
+    end
+  end
+end

--- a/libraries/firewall_firewalld.rb
+++ b/libraries/firewall_firewalld.rb
@@ -49,7 +49,7 @@ class Chef
         next if find(rule)
 
 	      r = zap(rule, act)
-	      r.raw = rule
+        r.raw rule
         if @new_resource.immediately
           r.run_action(act)
         else

--- a/libraries/firewall_firewalld.rb
+++ b/libraries/firewall_firewalld.rb
@@ -1,0 +1,83 @@
+# encoding: utf-8
+#
+# Cookbook Name:: zap
+# HWRP:: firewall
+#
+# Author:: Ronald Doorn <rdoorn@schubergphilis.com>
+#
+# Copyright:: 2015, Ronald Doorn.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'etc'
+require_relative 'default.rb'
+
+# zap_firewall
+class Chef
+  # provider
+  class Provider::ZapFirewallFirewalld < Provider::Zap
+    def collect
+      all = []
+
+      cmd = Mixlib::ShellOut.new("firewall-cmd --direct --get-all-rules")
+      cmd.run_command
+      cmd.stdout.split("\n").each do |line|
+        all << line
+        Chef::Log.debug("Zap output: #{line}")
+      end
+
+      all
+    end
+
+    # rubocop:disable MethodLength
+    def iterate(act)
+      return unless @new_resource.delayed || @new_resource.immediately
+
+      all = @collector.call
+      all.each do |rule|
+        next if find(rule)
+
+	      r = zap(rule, act)
+	      r.raw = rule
+        if @new_resource.immediately
+          r.run_action(act)
+        else
+          @run_context.resource_collection << r
+        end
+
+	      @new_resource.updated_by_last_action(true)
+      end
+
+    end
+
+    def find(item)
+      Chef::Log.debug("Starting Zap search for #{item}")
+      return unless item
+
+      @run_context.resource_collection.each do |r|
+        next unless r.resource_name == :firewall_rule
+        p = Chef::Provider::FirewallRuleFirewalld.new(r, @run_context)
+        rule = p.send('build_firewall_rule', p.new_resource.action.first)
+        rule.gsub!(/'/, "'*")
+
+        Chef::Log.debug("matching: [#{item.rstrip}] to [#{rule.rstrip}] => #{item.rstrip == rule.rstrip}")
+        return true if item.rstrip =~ /#{rule.rstrip}/
+      end
+      return false
+    end
+
+    # rubocop:enable MethodLength
+  end
+
+end

--- a/libraries/firewall_iptables.rb
+++ b/libraries/firewall_iptables.rb
@@ -59,7 +59,7 @@ class Chef
         next if find(rule)
 
 	      r = zap(native_rule, act)
-	      r.raw = native_rule
+        r.raw native_rule
         if @new_resource.immediately
           r.run_action(act)
         else

--- a/libraries/firewall_iptables.rb
+++ b/libraries/firewall_iptables.rb
@@ -1,0 +1,96 @@
+# encoding: utf-8
+#
+# Cookbook Name:: zap
+# HWRP:: firewall
+#
+# Author:: Ronald Doorn <rdoorn@schubergphilis.com>
+#
+# Copyright:: 2015, Ronald Doorn.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'etc'
+require_relative 'default.rb'
+
+# zap_firewall
+class Chef
+  # provider
+  class Provider::ZapFirewallIptables < Provider::Zap
+    def collect
+      # Collect all set rules
+      all = []
+
+      cmd = Mixlib::ShellOut.new("iptables-save")
+      cmd.run_command
+      line_count=0
+      ['INPUT', 'OUTPUT', 'FORWARD'].each do |chain|
+        line_count = 0
+        cmd.stdout.lines do |line|
+          next if line !~ /#{chain}/
+          next if line[0] != '-'
+	        line_count += 1
+          all << "#{line_count} #{line.chomp}"
+          Chef::Log.debug("Zap output: #{line_count} #{line.chomp}")
+        end
+      end
+
+      all
+    end
+
+    # rubocop:disable MethodLength
+    def iterate(act)
+      # Detect the rules that we set, and clean up if not found
+      return unless @new_resource.delayed || @new_resource.immediately
+
+      all = @collector.call
+      all.each do |rule|
+	      native_rule=rule.split(' ').drop(2).join(' ')
+        next if find(rule)
+
+	      r = zap(native_rule, act)
+	      r.raw = native_rule
+        if @new_resource.immediately
+          r.run_action(act)
+        else
+          @run_context.resource_collection << r
+        end
+
+	      @new_resource.updated_by_last_action(true)
+      end
+
+    end
+
+    def find(item)
+      Chef::Log.debug("Starting Zap search for #{item}")
+      return unless item
+
+      @run_context.resource_collection.each do |r|
+        next unless r.resource_name == :firewall_rule
+        p = Chef::Provider::FirewallRuleIptables.new(r, @run_context)
+        rule = p.send('build_firewall_rule', p.new_resource.action.first)
+
+        if p.new_resource.position
+           rule.gsub!(/(INPUT|OUTPUT|FORWARD)\s(\d+)/, '\2' + " -A " + '\1')
+        end
+
+        Chef::Log.debug("matching: [#{item.rstrip}] to [#{rule.rstrip}] => #{item.rstrip == rule.rstrip}")
+        return true if item.rstrip =~ /#{rule.rstrip}/
+      end
+      return false
+    end
+
+    # rubocop:enable MethodLength
+  end
+
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ maintainer_email  'nuspl@nvwls.com'
 license           'Apache 2.0'
 description       'Provides HWRPs for creating authoritative resources'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.8.2'
+version           '0.8.3'


### PR DESCRIPTION
This will clean up iptables or firewalld rules which are not created using the opscode firewall cookbook.
