### PR TITLE
fix "No such file or directory" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ zap Cookbook CHANGELOG
 ======================
 This file is used to list changes made in each version of the zap cookbook.
 
+v0.8.4
+------
+### Bugix
+- Support globbed directories, e.g. `/home/*/.ssh`
+
 v0.8.3
 ------
 ### Improvement

--- a/libraries/directory.rb
+++ b/libraries/directory.rb
@@ -54,7 +54,7 @@ class Chef
     private
     def walk(base)
       all = []
-      ::Dir.entries(base).each do |name|
+      ::Dir.glob(base).each do |name|
         next if name == '.' || name == '..'
         path = ::File.join(base, name)
 

--- a/libraries/directory.rb
+++ b/libraries/directory.rb
@@ -52,18 +52,22 @@ class Chef
     end
 
     private
+
     def walk(base)
       all = []
-      ::Dir.glob(base).each do |name|
-        next if name == '.' || name == '..'
-        path = ::File.join(base, name)
+      base = base.match('\*') ? ::Dir.glob(base) : [ base ]
+      base.each do |dir|
+        ::Dir.entries(dir).each do |name|
+          next if name == '.' || name == '..'
+          path = ::File.join(dir, name)
 
-        if ::File.directory?(path)
-          if @new_resource.recursive
-            all.concat walk(path)
+          if ::File.directory?(path)
+            if @new_resource.recursive
+              all.concat walk(path)
+            end
+          elsif ::File.fnmatch(@new_resource.pattern, path)
+            all.push path
           end
-        elsif ::File.fnmatch(@new_resource.pattern, path)
-          all.push path
         end
       end
       all

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ maintainer_email  'nuspl@nvwls.com'
 license           'Apache 2.0'
 description       'Provides HWRPs for creating authoritative resources'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.8.3'
+version           '0.8.4'

--- a/spec/cookbooks/test/recipes/directory.rb
+++ b/spec/cookbooks/test/recipes/directory.rb
@@ -11,3 +11,5 @@ zap_directory '/etc/profile.d' do
   pattern	node['directory']['pattern']
   recursive	node['directory']['recursive']
 end
+
+zap_directory '/home/*/.ssh'

--- a/spec/unit/directory_spec.rb
+++ b/spec/unit/directory_spec.rb
@@ -4,12 +4,12 @@ require 'spec_helper'
 
 describe 'test::directory' do
   before do
-    allow(Dir).to receive(:entries).and_call_original
-    allow(Dir).to receive(:entries)
+    allow(Dir).to receive(:glob).and_call_original
+    allow(Dir).to receive(:glob)
                    .with('/etc/profile.d')
                    .and_return(%w[crap.sh lang.sh lang.csh sub])
 
-    allow(Dir).to receive(:entries)
+    allow(Dir).to receive(:glob)
                    .with('/etc/profile.d/sub')
                    .and_return(%w[foo.sh foo.csh keep.sh])
 

--- a/spec/unit/directory_spec.rb
+++ b/spec/unit/directory_spec.rb
@@ -4,14 +4,27 @@ require 'spec_helper'
 
 describe 'test::directory' do
   before do
+    allow(Dir).to receive(:entries).and_call_original
+    allow(Dir).to receive(:entries)
+                   .with('/etc/profile.d')
+                   .and_return(%w[. .. crap.sh lang.sh lang.csh sub])
+
+    allow(Dir).to receive(:entries)
+                   .with('/etc/profile.d/sub')
+                   .and_return(%w[. .. foo.sh foo.csh keep.sh])
+
+    allow(Dir).to receive(:entries)
+                   .with('/home/user1/.ssh')
+                   .and_return(%w[. .. authorized_keys known_hosts])
+
+    allow(Dir).to receive(:entries)
+                   .with('/home/user2/.ssh')
+                   .and_return(%w[. .. authorized_keys known_hosts])
+
     allow(Dir).to receive(:glob).and_call_original
     allow(Dir).to receive(:glob)
-                   .with('/etc/profile.d')
-                   .and_return(%w[crap.sh lang.sh lang.csh sub])
-
-    allow(Dir).to receive(:glob)
-                   .with('/etc/profile.d/sub')
-                   .and_return(%w[foo.sh foo.csh keep.sh])
+                   .with('/home/*/.ssh')
+                   .and_return(%w[/home/user1/.ssh /home/user2/.ssh])
 
     allow(File).to receive(:directory?).and_call_original
     allow(File).to receive(:directory?)
@@ -35,6 +48,24 @@ describe 'test::directory' do
     allow(File).to receive(:directory?)
                    .with('/etc/profile.d/sub/keep.sh')
                    .and_return(false)
+    allow(File).to receive(:directory?)
+                   .with('/home/user1/.ssh')
+                   .and_return(true)
+    allow(File).to receive(:directory?)
+                   .with('/home/user1/.ssh/authorized_keys')
+                   .and_return(false)
+    allow(File).to receive(:directory?)
+                   .with('/home/user1/.ssh/known_hosts')
+                   .and_return(false)
+    allow(File).to receive(:directory?)
+                   .with('/home/user2/.ssh')
+                   .and_return(true)
+    allow(File).to receive(:directory?)
+                   .with('/home/user2/.ssh/authorized_keys')
+                   .and_return(false)
+    allow(File).to receive(:directory?)
+                   .with('/home/user2/.ssh/known_hosts')
+                   .and_return(false)
   end
 
   context '!pattern !recurive' do
@@ -51,6 +82,11 @@ describe 'test::directory' do
       expect(runner).not_to delete_file('/etc/profile.d/sub/foo.sh')
       expect(runner).not_to delete_file('/etc/profile.d/sub/foo.csh')
       expect(runner).not_to delete_file('/etc/profile.d/sub/keep.sh')
+
+      expect(runner).to delete_file('/home/user1/.ssh/authorized_keys')
+      expect(runner).to delete_file('/home/user1/.ssh/known_hosts')
+      expect(runner).to delete_file('/home/user2/.ssh/authorized_keys')
+      expect(runner).to delete_file('/home/user2/.ssh/known_hosts')
     end
   end
 
@@ -69,6 +105,11 @@ describe 'test::directory' do
       expect(runner).not_to delete_file('/etc/profile.d/sub/foo.sh')
       expect(runner).not_to delete_file('/etc/profile.d/sub/foo.csh')
       expect(runner).not_to delete_file('/etc/profile.d/sub/keep.sh')
+
+      expect(runner).to delete_file('/home/user1/.ssh/authorized_keys')
+      expect(runner).to delete_file('/home/user1/.ssh/known_hosts')
+      expect(runner).to delete_file('/home/user2/.ssh/authorized_keys')
+      expect(runner).to delete_file('/home/user2/.ssh/known_hosts')
     end
   end
 
@@ -87,6 +128,11 @@ describe 'test::directory' do
       expect(runner).to delete_file('/etc/profile.d/sub/foo.sh')
       expect(runner).to delete_file('/etc/profile.d/sub/foo.csh')
       expect(runner).not_to delete_file('/etc/profile.d/sub/keep.sh')
+
+      expect(runner).to delete_file('/home/user1/.ssh/authorized_keys')
+      expect(runner).to delete_file('/home/user1/.ssh/known_hosts')
+      expect(runner).to delete_file('/home/user2/.ssh/authorized_keys')
+      expect(runner).to delete_file('/home/user2/.ssh/known_hosts')
     end
   end
 
@@ -106,6 +152,11 @@ describe 'test::directory' do
       expect(runner).to delete_file('/etc/profile.d/sub/foo.sh')
       expect(runner).not_to delete_file('/etc/profile.d/sub/foo.csh')
       expect(runner).not_to delete_file('/etc/profile.d/sub/keep.sh')
+
+      expect(runner).to delete_file('/home/user1/.ssh/authorized_keys')
+      expect(runner).to delete_file('/home/user1/.ssh/known_hosts')
+      expect(runner).to delete_file('/home/user2/.ssh/authorized_keys')
+      expect(runner).to delete_file('/home/user2/.ssh/known_hosts')
     end
   end
 end


### PR DESCRIPTION
Hi,

Using 0.8.3 caused some cookbooks to fail when using the zap_directory resource with `Errno::ENOENT: No such file or directory @ dir_initialize`.

This has been fixed by changing `Dir.entries` to `Dir.glob` (along with tests).