### PR TITLE
workaround issue in chef 12

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -66,7 +66,7 @@ class Chef
       elsif @delayed == false && immediately == false
         r = dup
         r.delayed(true)
-        @run_context.resource_collection << r
+        @run_context.resource_collection.all_resources << r
       end
       @delayed
     end


### PR DESCRIPTION
using the shovel operator in chef 12 results in the resource being
added directly after the current resource, rather than at the end
of the resource list.

this workaround fetches all the resources and adds to the end of
the collection there.

This should fix #22 and has been tested with chef 12.4.1 and very lightly with chef 11.18.12.