### PR TITLE
Support using a descriptive resource name and add path var to zap_directory

### DIFF
--- a/libraries/directory.rb
+++ b/libraries/directory.rb
@@ -34,10 +34,15 @@ class Chef
       @provider = Provider::ZapDirectory
       @klass = [Chef::Resource::File, Chef::Resource::Template]
       @recursive = false
+      @path = ''
     end
 
     def recursive(arg = nil)
       set_or_return(:recursive, arg, equal_to: [true, false], default: false)
+    end
+
+    def path(arg = nil)
+      set_or_return(:path, arg, kind_of: String, default: '')
     end
   end
 
@@ -48,7 +53,8 @@ class Chef
     end
 
     def collect
-      walk(@new_resource.name)
+      path = !@new_resource.path.empty? ? @new_resource.path : @new_resource.name
+      walk(path)
     end
 
     private

--- a/spec/cookbooks/test/recipes/directory.rb
+++ b/spec/cookbooks/test/recipes/directory.rb
@@ -12,4 +12,6 @@ zap_directory '/etc/profile.d' do
   recursive	node['directory']['recursive']
 end
 
-zap_directory '/home/*/.ssh'
+zap_directory "clean up SSH directories" do
+  path '/home/*/.ssh'
+end


### PR DESCRIPTION
Makes it more like other resources in Chef and now you can use `lazy` and other helpers with it