### PR TITLE
Add the ability to define if the symlink source should be handled

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -132,7 +132,7 @@ class Chef
           if @new_resource.immediately
             r.run_action(act)
           else
-            @run_context.resource_collection << r
+            @run_context.resource_collection.all_resources << r
           end
           Chef::Log.debug "#{@new_resource} zapping #{r}"
           @new_resource.updated_by_last_action(true)
@@ -145,6 +145,9 @@ class Chef
       r = @klass.first.new(name, @run_context)
       r.cookbook_name = @new_resource.cookbook_name
       r.recipe_name = @new_resource.recipe_name
+      if r.respond_to?(:manage_symlink_source)
+        r.manage_symlink_source(@new_resource.manage_symlink_source)
+      end
       r.action(act)
       r
     end

--- a/libraries/directory.rb
+++ b/libraries/directory.rb
@@ -32,13 +32,18 @@ class Chef
       # Set the resource name and provider
       @resource_name = :zap_directory
       @provider = Provider::ZapDirectory
-      @klass = [Chef::Resource::File, Chef::Resource::Template]
+      @klass = [Chef::Resource::File, Chef::Resource::Link, Chef::Resource::Template]
       @recursive = false
+      @manage_symlink_source = false
       @path = ''
     end
 
     def recursive(arg = nil)
       set_or_return(:recursive, arg, equal_to: [true, false], default: false)
+    end
+
+    def manage_symlink_source(arg = nil)
+      set_or_return(:manage_symlink_source, arg, equal_to: [true, false], default: false)
     end
 
     def path(arg = nil)

--- a/spec/cookbooks/test/recipes/directory.rb
+++ b/spec/cookbooks/test/recipes/directory.rb
@@ -15,3 +15,17 @@ end
 zap_directory "clean up SSH directories" do
   path '/home/*/.ssh'
 end
+
+file "keep linux torrent" do
+  path "/data/downloads/linux-i-swear.torrent"
+  action :nothing
+end
+
+link "/data/downloads/osx.torrent" do
+  to "/data/downloads2/windows.torrent"
+end
+
+zap_directory "I like to keep things clean" do
+  path '/data/downloads'
+  manage_symlink_source true
+end

--- a/spec/unit/directory_spec.rb
+++ b/spec/unit/directory_spec.rb
@@ -21,6 +21,14 @@ describe 'test::directory' do
                    .with('/home/user2/.ssh')
                    .and_return(%w[. .. authorized_keys known_hosts])
 
+    allow(Dir).to receive(:entries)
+                   .with('/data/downloads')
+                   .and_return(%w[. .. linux-i-swear.torrent ubuntu.torrent redhat.torrent osx.torrent android.torrent])
+
+    allow(Dir).to receive(:entries)
+                   .with('/data/downloads2')
+                   .and_return(%w[. .. windows.torrent windows10.torrent])
+
     allow(Dir).to receive(:glob).and_call_original
     allow(Dir).to receive(:glob)
                    .with('/home/*/.ssh')
@@ -157,6 +165,25 @@ describe 'test::directory' do
       expect(runner).to delete_file('/home/user1/.ssh/known_hosts')
       expect(runner).to delete_file('/home/user2/.ssh/authorized_keys')
       expect(runner).to delete_file('/home/user2/.ssh/known_hosts')
+    end
+  end
+
+  context 'uses path and manages symlink' do
+    let :runner do
+      ChefSpec::SoloRunner.new(step_into: 'zap_directory').converge(described_recipe)
+    end
+
+    it 'converges' do
+      expect(runner).to create_link('/data/downloads/osx.torrent')
+                                  .with(to: '/data/downloads2/windows.torrent')
+      expect(runner).to delete_file('/data/downloads/android.torrent')
+      #expect(runner).to delete_file('/data/downloads2/windows10.torrent')
+
+      expect(runner).to delete_file('/data/downloads/ubuntu.torrent')
+      expect(runner).to delete_file('/data/downloads/redhat.torrent')
+      expect(runner).not_to delete_file('/data/downloads/linux-i-swear.torrent')
+      expect(runner).not_to delete_file('/data/download2/windows.torrent')
+      expect(runner).not_to delete_link('/data/downloads/osx.torrent')
     end
   end
 end


### PR DESCRIPTION
Prevents Chef warnings and include the Link resource in zap_directory. see #21

I am not really sure how to best test this I must admit.
