### PR TITLE
do not persist users and groups to chef node

### DIFF
--- a/libraries/groups.rb
+++ b/libraries/groups.rb
@@ -54,6 +54,7 @@ class Chef
 
         all << g.name if @filter.call(g)
       end
+      node.rm('zap', 'groups', 'keep')
 
       all
     end

--- a/libraries/users.rb
+++ b/libraries/users.rb
@@ -55,6 +55,7 @@ class Chef
 
         all << u.name if @filter.call(u)
       end
+      node.rm('zap', 'users', 'keep')
 
       all
     end


### PR DESCRIPTION
The list of users and groups that were being kept were automatically
being persisted to the chef server via the node object. This removes
those attributes to ensure that they're not present in the node object.

The list does not need to be persisted as it is generated statically on
each run.

I'm opening this PR because we have a situation where the wrapper cookbook using zap_user and zap_group adds the list of logged in users to the 'keep' attribute. As this changes over time it causes the node object to change (which in turn results in audit messages for the changing node object).