### PR TITLE
chef versions >= 12.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ zap Cookbook CHANGELOG
 ======================
 This file is used to list changes made in each version of the zap cookbook.
 
+v0.12.0
+### Improvement
+- added unit tests for zap_users and zap_yum_repos
+- adapt logic to make it compatable with versions 12.14 and higher
+
 v0.11.4
 -------
 ### Enhancement

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 
 group :unit do
+  #gem 'chef', '12.16.42'
+  #gem 'chef', '12.13.37'
+  #gem 'chef', '11.18.12'
   gem 'berkshelf'
   gem 'chefspec'
 end

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -147,9 +147,8 @@ class Chef
           Chef::Log.debug "#{@new_resource} zapping #{r}"
           if @new_resource.immediately
             r.run_action(act)
-          else
-            @run_context.resource_collection << r
           end
+          @run_context.resource_collection << r
         end
       end unless extraneous.empty?
     end

--- a/libraries/users.rb
+++ b/libraries/users.rb
@@ -23,6 +23,14 @@
 require 'etc'
 require_relative 'default.rb'
 
+class Chef
+  class Resource
+    class User
+      resource_name :user if respond_to?(:resource_name)
+    end
+  end
+end
+
 # zap_users '/etc/passwd'
 class Chef
   # resource

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ maintainer_email  'nuspl@nvwls.com'
 license           'Apache 2.0'
 description       'Provides HWRPs for creating authoritative resources'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.11.4'
+version           '0.12.0'

--- a/spec/cookbooks/test/attributes/default.rb
+++ b/spec/cookbooks/test/attributes/default.rb
@@ -2,3 +2,4 @@
 
 default['directory']['recursive'] = nil
 default['directory']['pattern'] = nil
+default['users']['pattern'] = nil

--- a/spec/cookbooks/test/recipes/users.rb
+++ b/spec/cookbooks/test/recipes/users.rb
@@ -1,17 +1,10 @@
 # encoding: UTF-8
 
-`useradd larry`
-`useradd moe`
-`useradd -r curly`
-`useradd -r test0`
-`useradd -r test1`
+user 'moe'
 
 zap_users '/etc/passwd' do
+  pattern	node['users']['pattern']
   filter do |u|
     u.uid > 500
   end
-end
-
-zap_users 'passwd' do
-  pattern 'test*'
 end

--- a/spec/cookbooks/test/recipes/yum_repos.rb
+++ b/spec/cookbooks/test/recipes/yum_repos.rb
@@ -1,0 +1,10 @@
+# encoding: UTF-8
+
+yum_repository 'os' do
+  description 'os'
+  baseurl 'https://www.example.com/repo/os'
+end
+
+zap_yum_repos '/etc/yum.repos.d' do
+  delayed true
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,13 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
+RSpec.configure do |config|
+  # Specify the Chef log_level (default: :warn)
+  config.log_level = :warn
+  config.platform = 'centos'
+  config.version  = '6.8'
+end
+
 ChefSpec::SoloRunner = ChefSpec::Runner if ChefSpec::VERSION.to_f < 4.1
 
 at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -1,0 +1,43 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+describe 'test::users' do
+  before(:each) do
+    allow(IO).to receive(:foreach).and_call_original
+    allow(IO).to receive(:foreach).with("/etc/passwd")
+                   .and_yield('curly:*:100:200::/var/empty:/usr/bin/false\n')
+                   .and_yield('moe:*:501:200::/var/empty:/usr/bin/false\n')
+                   .and_yield('larry:*:502:200::/var/empty:/usr/bin/false\n')
+                   .and_yield('waldo:*:503:200::/var/empty:/usr/bin/false\n')
+  end
+
+  context 'without a pattern' do
+    let(:runner) do
+      ChefSpec::SoloRunner.new(step_into: 'zap_users') do |node|
+      end.converge(described_recipe)
+    end
+
+    it 'remove all unknown ids higher then 500' do
+      expect(runner).not_to remove_user('curly')
+      expect(runner).not_to remove_user('moe')
+      expect(runner).to remove_user('larry')
+      expect(runner).to remove_user('waldo')
+    end
+  end
+
+  context 'with a pattern' do
+    let(:runner) do
+      ChefSpec::SoloRunner.new(step_into: 'zap_users') do |node|
+        node.normal['users']['pattern'] = '*aldo*'
+      end.converge(described_recipe)
+    end
+
+    it 'only username matching the pattern' do
+      expect(runner).not_to remove_user('curly')
+      expect(runner).not_to remove_user('moe')
+      expect(runner).not_to remove_user('larry')
+      expect(runner).to remove_user('waldo')
+    end
+  end
+end

--- a/spec/unit/yum_repos_spec.rb
+++ b/spec/unit/yum_repos_spec.rb
@@ -1,0 +1,22 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+describe 'test::yum_repos' do
+  before(:each) do
+    allow(Dir).to receive(:glob).and_call_original
+    allow(Dir).to receive(:glob)
+                   .with('/etc/yum.repos.d/*.repo')
+                   .and_return(%w[/etc/yum.repos.d/os.repo /etc/yum.repos.d/evil.repo])
+  end
+
+  let(:runner) do
+    ChefSpec::SoloRunner.new(step_into: 'zap_yum_repos') do |node|
+    end.converge(described_recipe)
+  end
+
+  it 'removes unmanaged repos' do
+    expect(runner).to     delete_yum_repository('evil')
+    expect(runner).not_to delete_yum_repository('os')
+  end
+end


### PR DESCRIPTION
This cookbook failed with chef version 12.14 and higher. This PR fixes that and issue 34.
I've added some unit tests as well and successfully ran against chef 11, 12.13 and 12.16.
