### PR TITLE
Fix lambda filter argument error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ zap Cookbook CHANGELOG
 ======================
 This file is used to list changes made in each version of the zap cookbook.
 
+v0.15.1
+### Bugfix
+- Fix bug with filter property lamba expression
+
 v0.15.0
 ### Enhancement
 - Add `force` to force running of `zap` when there is an override_runlist

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -31,7 +31,7 @@ class Chef
 
       @delayed = false
       @pattern = '*'
-      @filter = -> { true }
+      @filter = lambda { |_| true }
 
       # Set the resource name and provider
       @resource_name = :zap

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'nuspl@nvwls.com'
 license           'Apache 2.0'
 description       'Provides HWRPs for creating authoritative resources'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.15.0'
+version           '0.15.1'
 
 %w(amazon centos fedora oracle redhat scientific).each do |os|
   supports os


### PR DESCRIPTION
Hi,

When using zap I came across this error:

```
================================================================================
Error executing action `remove` on resource 'zap_users[/etc/passwd]'
================================================================================

ArgumentError
-------------
wrong number of arguments (given 1, expected 0)

Cookbook Trace:
---------------
/tmp/kitchen/cache/cookbooks/zap/libraries/default.rb:32:in `block in initialize'
/tmp/kitchen/cache/cookbooks/zap/libraries/users.rb:63:in `block in collect'
/tmp/kitchen/cache/cookbooks/zap/libraries/users.rb:56:in `foreach'
/tmp/kitchen/cache/cookbooks/zap/libraries/users.rb:56:in `collect'
/tmp/kitchen/cache/cookbooks/zap/libraries/default.rb:130:in `call'
/tmp/kitchen/cache/cookbooks/zap/libraries/default.rb:130:in `iterate'
/tmp/kitchen/cache/cookbooks/zap/libraries/default.rb:113:in `action_remove'

Resource Declaration:
---------------------
# In /tmp/kitchen/cache/cookbooks/matrixreloaded/recipes/default.rb

185: zap_users  '/etc/passwd'
186: zap_groups '/etc/groups'

Compiled Resource:
------------------
# Declared in /tmp/kitchen/cache/cookbooks/matrixreloaded/recipes/default.rb:185:in `from_file'

zap_users("/etc/passwd") do
  provider Chef::Provider::ZapUsers
  action :remove
  supports [:filter]
  retries 0
  retry_delay 2
  default_guard_interpreter :default
  delayed true
  pattern "*"
  filter #<Proc:0x000000038c87c0@/tmp/kitchen/cache/cookbooks/zap/libraries/default.rb:32 (lambda)>
  klass [Chef::Resource::User]
  declared_type :zap_users
  cookbook_name "matrixreloaded"
  recipe_name "default"
end
```

This PR fixes this error and now the `zap_users` resource appears to be working as expected.  I can't explain why as functionally I believe nothing changes but Chef didn't seem to like the `-> { true }`.
